### PR TITLE
配列のシャッフル処理を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
             { sound: "q117.wav", answer: "レイジョ", image: "r117.png" }
         ];
         
-        let questions = allQuestions.slice().sort(() => Math.random() - 0.5).slice(0, 10);
+        let questions = allQuestions.map(q => ({q: q, w: Math.random()})).sort((a, b) => a.w - b.w).map(a => a.q).slice(0, 10);
         let currentQuestion = 0;
         let score = 0;
         


### PR DESCRIPTION
JavaScript の sort の引数に渡す comparator は順序について一貫性を保たなければなりません。
すなわち、

1. 元の配列に順序を定め、
2. その順序に基づいて一貫した返り値を決める

必要があります。そうしないと、今回のように[要素に偏りが生じたり](https://x.com/UtaXD_ow2/status/1901582185548972330)、言語によっては[実行時エラー](https://stackoverflow.com/questions/11441666/java-error-comparison-method-violates-its-general-contract)や[未定義動作](https://stackoverflow.com/questions/34834125/stdsort-is-passing-a-faulty-comparator-undefined-behavior)が発生することがあります。

「一様ランダムに結果を返しているのになぜ要素が偏るのか？」については、例えば挿入ソートのアルゴリズムを考えてみると分かりやすいでしょう。挿入ソートは、各要素について、既存の要素と比較を繰り返しながら適切な挿入位置を決定します。このとき、挿入される位置は最初に順序が反転した位置です。すなわち、比較結果が一様ランダムならば、1/2 の確率で順序が反転するため、

- 0 番目に配置される確率: 1/2
- 1 番目に配置される確率: 1/4
- 2 番目に配置される確率: 1/8
- 3 番目に配置される確率: 1/16
- ...

と配列の後方に要素が挿入される確率が指数的に低くなっていきます。

この PR では、重みを事前に `Math.random()` によって計算し、順序を重みの大小で決定することで一様ランダムなシャッフル結果が得られるようにコードを修正しています。